### PR TITLE
replace Unicode EN DASH character with ASCII hyphen

### DIFF
--- a/parked-domain-how-to.md
+++ b/parked-domain-how-to.md
@@ -46,7 +46,7 @@ When using a wildcard selector to set an empty public key, you indicate that all
 ## SPF
 Set an an empty policy (not mentioning any ip-adresses or hostnames which are allowed to send mail) and a hard fail.
 
-`example.nl. IN TXT "v=spf1 –all"`
+`example.nl. IN TXT "v=spf1 -all"`
  
 # Domain without a website
 Apply the following settings to domains not using a website.


### PR DESCRIPTION
The latter of which is valid in a DNS response; otherwise, you get

```
example.nl. 300 IN TXT "v=spf1 \226\128\147all"
```